### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Specific files
+cython/wrapper.cpp
+

--- a/cython/setup.py
+++ b/cython/setup.py
@@ -115,7 +115,7 @@ ext = Extension('gpuadder',
                 # we're only going to use certain compiler args with nvcc and not with gcc
                 # the implementation of this trick is in customize_compiler() below
                 extra_compile_args={'gcc': [],
-                                    'nvcc': ['-arch=sm_20', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'"]},
+                                    'nvcc': ['-arch=sm_30', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'"]},
                 include_dirs = [numpy_include, CUDA['include'], 'src'])
 
 

--- a/cython/setup.py
+++ b/cython/setup.py
@@ -1,3 +1,4 @@
+from future.utils import iteritems
 import  os
 from os.path import join as pjoin
 from setuptools import setup
@@ -41,7 +42,7 @@ def locate_cuda():
     cudaconfig = {'home':home, 'nvcc':nvcc,
                   'include': pjoin(home, 'include'),
                   'lib64': pjoin(home, 'lib64')}
-    for k, v in cudaconfig.iteritems():
+    for k, v in iteritems(cudaconfig):
         if not os.path.exists(v):
             raise EnvironmentError('The CUDA %s path could not be located in %s' % (k, v))
 

--- a/cython/setup.py
+++ b/cython/setup.py
@@ -7,6 +7,7 @@ from Cython.Distutils import build_ext
 import subprocess
 import numpy
 
+
 def find_in_path(name, path):
     "Find a file in a search path"
     #adapted fom http://code.activestate.com/recipes/52224-find-a-file-given-a-search-path/
@@ -47,41 +48,18 @@ def locate_cuda():
             raise EnvironmentError('The CUDA %s path could not be located in %s' % (k, v))
 
     return cudaconfig
-CUDA = locate_cuda()
-
-
-# Obtain the numpy include directory.  This logic works across numpy versions.
-try:
-    numpy_include = numpy.get_include()
-except AttributeError:
-    numpy_include = numpy.get_numpy_include()
-
-
-ext = Extension('gpuadder',
-                sources=['src/manager.cu', 'wrapper.pyx'],
-                library_dirs=[CUDA['lib64']],
-                libraries=['cudart'],
-                language='c++',
-                runtime_library_dirs=[CUDA['lib64']],
-                # this syntax is specific to this build system
-                # we're only going to use certain compiler args with nvcc and not with gcc
-                # the implementation of this trick is in customize_compiler() below
-                extra_compile_args={'gcc': [],
-                                    'nvcc': ['-arch=sm_20', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'"]},
-                include_dirs = [numpy_include, CUDA['include'], 'src'])
-
 
 
 def customize_compiler_for_nvcc(self):
     """inject deep into distutils to customize how the dispatch
     to gcc/nvcc works.
-    
+
     If you subclass UnixCCompiler, it's not trivial to get your subclass
     injected in, and still have the right customizations (i.e.
     distutils.sysconfig.customize_compiler) run on it. So instead of going
     the OO route, I have this. Note, it's kindof like a wierd functional
     subclassing going on."""
-    
+
     # tell the compiler it can processes .cu
     self.src_extensions.append('.cu')
 
@@ -115,6 +93,32 @@ class custom_build_ext(build_ext):
     def build_extensions(self):
         customize_compiler_for_nvcc(self.compiler)
         build_ext.build_extensions(self)
+
+
+
+CUDA = locate_cuda()
+
+# Obtain the numpy include directory.  This logic works across numpy versions.
+try:
+    numpy_include = numpy.get_include()
+except AttributeError:
+    numpy_include = numpy.get_numpy_include()
+
+
+ext = Extension('gpuadder',
+                sources=['src/manager.cu', 'wrapper.pyx'],
+                library_dirs=[CUDA['lib64']],
+                libraries=['cudart'],
+                language='c++',
+                runtime_library_dirs=[CUDA['lib64']],
+                # this syntax is specific to this build system
+                # we're only going to use certain compiler args with nvcc and not with gcc
+                # the implementation of this trick is in customize_compiler() below
+                extra_compile_args={'gcc': [],
+                                    'nvcc': ['-arch=sm_20', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'"]},
+                include_dirs = [numpy_include, CUDA['include'], 'src'])
+
+
 
 setup(name='gpuadder',
       # random metadata. there's more you can supploy


### PR DESCRIPTION
These changes primarily consist of:
* making setup.py compatible with both Python 2 and Python 3
* moving function definitions in setup.py to the top of the file so that the package-specific definitions are grouped together at the end
* increment the CUDA architecture to sm_30 since sm_20 is deprecated